### PR TITLE
findFeatures now checks correct set of features

### DIFF
--- a/components/FinalBuild/index.tsx
+++ b/components/FinalBuild/index.tsx
@@ -109,7 +109,7 @@ const ReviewYourBuild = () => {
   }
 
   function findFeatures(array) {
-    const dataObject = array.find((item) => item.type === 'data')
+    const dataObject = array.find((item) => item.type === 'dataStreaming')
     const finalFeatures = []
     for (let i = 0; i < dataObject?.data?.lists?.length; i++) {
       // eslint-disable-next-line prettier/prettier


### PR DESCRIPTION
findFeatures function was checking for the streaming data node under the wrong type.
This meant that none of the workloads were actually sent to the xnode server.

This is what the Streaming data's node type actually is:
![pic-selected-240124-1637-14](https://github.com/bruno353/openmesh-xnode/assets/48117609/7d1f77d4-73bf-4d88-9014-091ec6e0ddf2)

So, that's the fix, changed `type === 'data'` to `type === 'dataStreaming'` to reflect the UI. I guess you could do it the other way around, but I found foundFeatures first.

Haven't tested it, but now it should actually upload the workloads to the azure server and backend. 😎